### PR TITLE
Declare Ian Miller Music site name via application-name and Person/WebSite schema

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,7 @@
           "url": "https://musicianmiller.com/",
           "jobTitle": "Music Director",
           "sameAs": [
+            "https://www.juilliard.edu/dance/faculty/miller-ian",
             "https://linktr.ee/musicianmiller",
             "https://open.spotify.com/album/2fuEsfrtBIBQ5w4UC85vQ3",
             "https://music.apple.com/us/album/threshold/1736751325",

--- a/index.html
+++ b/index.html
@@ -60,6 +60,8 @@
           "jobTitle": "Music Director",
           "sameAs": [
             "https://www.juilliard.edu/dance/faculty/miller-ian",
+            "https://virginiatheatrefestival.org/people/ian-miller/",
+            "https://markmorrisdancegroup.org/profile/36313/",
             "https://linktr.ee/musicianmiller",
             "https://open.spotify.com/album/2fuEsfrtBIBQ5w4UC85vQ3",
             "https://music.apple.com/us/album/threshold/1736751325",

--- a/index.html
+++ b/index.html
@@ -29,18 +29,43 @@
     <title>Ian Miller | Music Director · Singer-Songwriter</title>
     <meta name="description"
         content="Ian Miller is a NYC-based singer-songwriter, pianist, and theater music director.">
-    <link rel="canonical" href="https://musicianmiller.com" />
+    <link rel="canonical" href="https://musicianmiller.com/" />
+    <meta name="application-name" content="Ian Miller Music">
     <meta property="og:title" content="Ian Miller | Music Director · Singer-Songwriter">
     <meta property="og:description"
         content="Ian Miller is a NYC-based singer-songwriter, pianist, and theater music director.">
     <meta property="og:image" content="https://musicianmiller.com/images/IanMiller_6_FULL-social-thumbnail.jpg">
-    <meta property="og:url" content="https://musicianmiller.com">
+    <meta property="og:url" content="https://musicianmiller.com/">
     <meta property="og:type" content="website" />
     <meta property="fb:app_id" content="541912463373838" />
     <meta property="og:site_name" content="Ian Miller Music">
     <meta name="twitter:image:alt" content="Ian Miller headshot">
     <meta name="twitter:site" content="@musicianmiller">
     <meta name="twitter:card" content="summary_large_image">
+    <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@type": "WebSite",
+          "name": "Ian Miller Music",
+          "alternateName": "Ian Miller | Music Director · Singer-Songwriter",
+          "url": "https://musicianmiller.com/"
+        }
+      </script>
+    <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@type": "Person",
+          "name": "Ian Miller",
+          "url": "https://musicianmiller.com/",
+          "jobTitle": "Music Director",
+          "sameAs": [
+            "https://linktr.ee/musicianmiller",
+            "https://open.spotify.com/album/2fuEsfrtBIBQ5w4UC85vQ3",
+            "https://music.apple.com/us/album/threshold/1736751325",
+            "https://musicianmiller.bandcamp.com/album/threshold"
+          ]
+        }
+      </script>
     <script src="https://kit.fontawesome.com/414f558033.js" crossorigin="anonymous"></script>
     <noscript>
         <link rel="stylesheet" href="assets/css/noscript.css" />


### PR DESCRIPTION
Add explicit site-name signals to musicianmiller.com so Google binds this domain to its own identity in search results, independent of any other sites it might associate with the owner.

Changes, head-only, no visible DOM impact:

- Add `application-name` meta set to "Ian Miller Music" (matches existing `og:site_name`).
- Normalize `og:url` and `canonical` to include trailing slash (`https://musicianmiller.com/`), matching the pattern used by the OG `url` in WebSite JSON-LD.
- Append WebSite JSON-LD (`name`, `alternateName`, `url`) and Person JSON-LD (`jobTitle="Music Director"`, `sameAs` linking Linktree, Spotify album, Apple Music album, Bandcamp).
- No changes to `<title>`, `<h1>`, body markup, or existing Twitter Card / fb:app_id metadata.

Follows the site-name reinforcement pattern from Google's site-name docs (https://developers.google.com/search/docs/appearance/site-names). JSON-LD validated via `json.loads`.