### PR TITLE
Add alumniOf Yale University to Person schema

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,10 @@
           "name": "Ian Miller",
           "url": "https://musicianmiller.com/",
           "jobTitle": "Music Director",
+          "alumniOf": {
+            "@type": "CollegeOrUniversity",
+            "name": "Yale University"
+          },
           "sameAs": [
             "https://www.juilliard.edu/dance/faculty/miller-ian",
             "https://virginiatheatrefestival.org/people/ian-miller/",


### PR DESCRIPTION
Add Ian's Yale University undergraduate education to the Person JSON-LD block. `alumniOf` is a strong Knowledge Graph identity signal — authoritative, verifiable, and helps Google bind this site's Person entity to Ian uniquely.

Source: Ian's own resume at `/documents/ian-miller-resume.pdf` lists "Yale University, B.A. in Music (Distinction in the Major)". Also confirmed in the Mark Morris Dance Group bio already linked from `sameAs`.

Change is a single four-line addition to the Person JSON-LD block in the homepage head. No visible DOM impact.

JSON-LD validated via `json.loads`.